### PR TITLE
Update the token and refresh endpoints for open source users of GTM O…

### DIFF
--- a/Source/GTMOAuth2Authentication.m
+++ b/Source/GTMOAuth2Authentication.m
@@ -808,12 +808,23 @@ finishedRefreshWithFetcher:(GTMOAuth2Fetcher *)fetcher
     if ([redirectURI length] > 0) {
       [paramsDict setObject:redirectURI forKey:@"redirect_uri"];
     }
-    
+
     NSString *scope = self.scope;
     if ([scope length] > 0) {
       [paramsDict setObject:scope forKey:@"scope"];
     }
-    
+
+    // This code doesn't set the "state" value for verifying the redirect as
+    // described at
+    //   https://developers.google.com/identity/protocols/OpenIDConnect#state-param
+    // for two reasons:
+    //
+    // 1. Sign-in happens entirely in a WebView controlled by the app
+    //
+    // 2. For sign in to Google services, the completion of sign in is
+    //    determined not by redirect but rather by a change in document.title
+    //    to a string containing a code or error (see the window/view controller).
+
     fetchType = kGTMOAuth2FetchTypeToken;
   } else if (assertion) {
     // We have an assertion string

--- a/Source/GTMOAuth2SignIn.m
+++ b/Source/GTMOAuth2SignIn.m
@@ -90,13 +90,15 @@ finishedWithFetcher:(GTMOAuth2Fetcher *)fetcher
 @synthesize networkLossTimeoutInterval = networkLossTimeoutInterval_;
 
 #if !GTM_OAUTH2_SKIP_GOOGLE_SUPPORT
+// Endpoint URLs are available at https://accounts.google.com/.well-known/openid-configuration
+
 + (NSURL *)googleAuthorizationURL {
-  NSString *str = @"https://accounts.google.com/o/oauth2/auth";
+  NSString *str = @"https://accounts.google.com/o/oauth2/v2/auth";
   return [NSURL URLWithString:str];
 }
 
 + (NSURL *)googleTokenURL {
-  NSString *str = @"https://accounts.google.com/o/oauth2/token";
+  NSString *str = @"https://www.googleapis.com/oauth2/v4/token";
   return [NSURL URLWithString:str];
 }
 
@@ -625,6 +627,8 @@ finishedWithFetcher:(GTMOAuth2Fetcher *)fetcher
         if ([part2 length] > 0) {
           NSData *data = [[self class] decodeWebSafeBase64:part2];
           if ([data length] > 0) {
+            // We trust this id_token data because it was obtained via SSL connection
+            // directly to the authoritative server.
             [self updateGoogleUserInfoWithData:data];
             if ([[auth userID] length] > 0 && [[auth userEmail] length] > 0) {
               // We obtained user ID and email from the ID token.

--- a/Source/Mac/GTMOAuth2WindowController.h
+++ b/Source/Mac/GTMOAuth2WindowController.h
@@ -83,7 +83,8 @@
 
 @class GTMOAuth2SignIn;
 
-@interface GTMOAuth2WindowController : NSWindowController {
+@interface GTMOAuth2WindowController : NSWindowController<WebPolicyDelegate,
+                                                          WebResourceLoadDelegate> {
  @private
   // IBOutlets
   NSButton *keychainCheckbox_;


### PR DESCRIPTION
…Auth 2

Add some comments explaining why the code doesn't need to set and check sign-in state parameter, nor to validate the returned ID token.
While iSL (iOS SSO) compiles GTM OAuth 2 in, it doesn't rely on these endpoints.
Web apps are encouraged to fetch a discovery doc to get the endpoints, but for performance and stability we've always hardcoded the endpoints into the native clients.
Build fixes for Xcode 7.