### PR TITLE
Bump the deployment targets for the GTMOAuth2 podspec.

### DIFF
--- a/GTMOAuth2.podspec
+++ b/GTMOAuth2.podspec
@@ -12,11 +12,11 @@ Pod::Spec.new do |s|
       applications to sign in to services using OAuth 2 for authentication
       and authorization.
       
-      This version can be used with iOS ≥ 6.0 or OS X ≥ 10.8.
+      This version can be used with iOS ≥ 7.0 or OS X ≥ 10.9.
                    DESC
 
-  s.ios.deployment_target = '6.0'
-  s.osx.deployment_target = '10.8'
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.9'
   s.requires_arc = false
 
   s.source_files = 'Source/*.{h,m}'


### PR DESCRIPTION
 The dependency on GTMSessionFetcher prevents this from being used on iOS 6 and OSX 10.8. We should be able to create a Podspec that works around this, but this is a simple solution for now.