### PR TITLE
Modify GTMOAuth2Authentication.h to optionally import GTMSessionFetcher via a framework-like path

### DIFF
--- a/GTMOAuth2.podspec
+++ b/GTMOAuth2.podspec
@@ -25,6 +25,8 @@ Pod::Spec.new do |s|
   s.osx.source_files = 'Source/Mac/*.{h,m}'
   s.osx.resources = 'Source/Mac/*.xib'
 
+  s.user_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GTM_OAUTH2_USE_FRAMEWORK_IMPORTS=1' }
+
   s.frameworks = 'Security', 'SystemConfiguration'
   s.dependency 'GTMSessionFetcher', '~> 1.1'
 end

--- a/Source/GTMOAuth2Authentication.h
+++ b/Source/GTMOAuth2Authentication.h
@@ -29,10 +29,22 @@
   #define GTMOAUTH2AUTHENTICATION_DEPRECATE_OLD_ENUMS 1
 #endif
 
+#ifndef GTM_OAUTH2_USE_FRAMEWORK_IMPORTS
+#define GTM_OAUTH2_USE_FRAMEWORK_IMPORTS 0
+#endif
+
 #if GTM_USE_SESSION_FETCHER
-  #import "GTMSessionFetcher.h"
+  #if GTM_OAUTH2_USE_FRAMEWORK_IMPORTS
+    #import <GTMSessionFetcher/GTMSessionFetcher.h>
+  #else
+    #import "GTMSessionFetcher.h"
+  #endif  // GTM_OAUTH2_USE_FRAMEWORK_IMPORTS
 #else
-  #import "GTMHTTPFetcher.h"
+  #if GTM_OAUTH2_USE_FRAMEWORK_IMPORTS
+    #import <GTMHTTPFetcher/GTMHTTPFetcher.h>
+  #else
+    #import "GTMHTTPFetcher.h"
+  #endif  // GTM_OAUTH2_USE_FRAMEWORK_IMPORTS
 #endif  // GTM_USE_SESSION_FETCHER
 
 #define GTMOAuth2Fetcher GTMBridgeFetcher


### PR DESCRIPTION
This supports the Cocoapods use_frameworks! use case, and is enabled in the Podspec, but is disabled by default, therefore making this change a no-op for non-CocoaPods use cases.