### PR TITLE
Enable the NSUserDefautls hack for iOS 10.1

### DIFF
--- a/GTMOAuth2.podspec
+++ b/GTMOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'GTMOAuth2'
-  s.version      = '1.1.3'
+  s.version      = '1.1.4'
   s.author       = 'Google Inc.'
   s.homepage     = 'https://github.com/google/gtm-oauth2'
   s.license      = { :type => 'Apache', :file => 'LICENSE' }

--- a/Source/Touch/GTMOAuth2ViewControllerTouch.m
+++ b/Source/Touch/GTMOAuth2ViewControllerTouch.m
@@ -944,8 +944,10 @@ static Class gSignInClass = Nil;
 // The Keychain API isn't available on the iPhone simulator in SDKs before 3.0,
 // so, on early simulators we use a fake API, that just writes, unencrypted, to
 // NSUserDefaults.  Additionally, to mitigate a keychain bug in the iOS 10 simulator
-// that causes SecItemAdd to fail with -34018, we enable NSUserDefaults storage for iOS 10.0.x.
-#if TARGET_IPHONE_SIMULATOR && (__IPHONE_OS_VERSION_MAX_ALLOWED < 30000 || __IPHONE_OS_VERSION_MAX_ALLOWED == 100000)
+// that causes SecItemAdd to fail with -34018, we enable NSUserDefaults storage for iOS 10.0.x and
+// 10.1.x.
+#if TARGET_IPHONE_SIMULATOR && (__IPHONE_OS_VERSION_MAX_ALLOWED < 30000 || \
+    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 100000 && __IPHONE_OS_VERSION_MAX_ALLOWED <= 100100))
 #pragma mark Simulator
 
 // Simulator - just simulated, not secure.


### PR DESCRIPTION
Looks like Apple still hasn't fixed the Keychain problem, enable the hack
on 10.1 also.