### PR TITLE
Complete the prototype of the block.

### DIFF
--- a/GTMOAuth2.podspec
+++ b/GTMOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'GTMOAuth2'
-  s.version      = '1.1.4'
+  s.version      = '1.1.5'
   s.author       = 'Google Inc.'
   s.homepage     = 'https://github.com/google/gtm-oauth2'
   s.license      = { :type => 'Apache', :file => 'LICENSE' }

--- a/Source/Touch/GTMOAuth2ViewControllerTouch.m
+++ b/Source/Touch/GTMOAuth2ViewControllerTouch.m
@@ -387,7 +387,7 @@ static GTMOAuth2Keychain* gGTMOAuth2DefaultKeychain = nil;
 
 - (void)popView {
 #if NS_BLOCKS_AVAILABLE
-  void (^popViewBlock)() = self.popViewBlock;
+  void (^popViewBlock)(void) = self.popViewBlock;
 #else
   id popViewBlock = nil;
 #endif


### PR DESCRIPTION
Should work around warnings in newer Xcodes.

Also bump the podspec version to roll this into a release.