### PR TITLE
Update GTMOAuth2Authentication.m

### DIFF
--- a/Source/GTMOAuth2Authentication.m
+++ b/Source/GTMOAuth2Authentication.m
@@ -1120,7 +1120,7 @@ finishedRefreshWithFetcher:(GTMOAuth2Fetcher *)fetcher
   // the server expects the expiration
   NSDate *date = nil;
   NSNumber *expiresIn = self.expiresIn;
-  if (expiresIn) {
+  if (expiresIn != nil) {
     unsigned long deltaSeconds = [expiresIn unsignedLongValue];
     if (deltaSeconds > 0) {
       date = [NSDate dateWithTimeIntervalSinceNow:deltaSeconds];


### PR DESCRIPTION
fix for XCode 9 static analysis warning:

`GTMOAuth2Authentication.m:1123:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue`